### PR TITLE
some cloud provided db require dbname

### DIFF
--- a/cmd/dbmigrate/main.go
+++ b/cmd/dbmigrate/main.go
@@ -78,10 +78,12 @@ func _main() error {
 	}
 
 	if doServerReadyWait := serverReadyWait > 0; doServerReadyWait || doCreateDB {
-		connString, dbName, err := dbmigrate.BaseDatabaseURL(driverName, databaseURL)
+		driverName, _, _ = dbmigrate.SanitizeDriverNameURL(driverName, databaseURL)
+		connString, dbName, err := dbmigrate.BaseDatabaseURL(driverName, databaseURL, "/"+driverName)
 		if err != nil {
 			return errors.Wrapf(err, "database url without dbname")
 		}
+		log.Printf("connString=%q\n", connString)
 
 		if doServerReadyWait && driverName != "sqlite3" {
 			ctx, cancel := context.WithTimeout(context.Background(), serverReadyWait)

--- a/lib.go
+++ b/lib.go
@@ -31,7 +31,7 @@ func SanitizeDriverNameURL(driverName string, databaseURL string) (string, strin
 }
 
 // BaseDatabaseURL returns the connection string to connect to the server (without the database name)
-func BaseDatabaseURL(driverName string, databaseURL string) (string, string, error) {
+func BaseDatabaseURL(driverName string, databaseURL string, defaultDbName string) (string, string, error) {
 	driverName, databaseURL, err := SanitizeDriverNameURL(driverName, databaseURL)
 	if err != nil {
 		return "", "", err
@@ -40,7 +40,7 @@ func BaseDatabaseURL(driverName string, databaseURL string) (string, string, err
 	paths := strings.Split(databaseURL, "/")
 	pathlen := len(paths)
 	requestURI := strings.Split(paths[pathlen-1], "?")
-	basePaths := []string{strings.Join(paths[:pathlen-1], "/") + "/"}
+	basePaths := []string{strings.Join(paths[:pathlen-1], "/") + defaultDbName}
 
 	if len(requestURI) > 1 {
 		basePaths = append(basePaths, requestURI[1:]...)

--- a/lib_test.go
+++ b/lib_test.go
@@ -3,11 +3,13 @@ package dbmigrate
 import (
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBaseDatabaseURL(t *testing.T) {
+	defaultDbName := "/" + time.Now().Format("db20060102150405")
 	testCases := []struct {
 		givenDatabaseURL string
 		expectedBaseURL  string
@@ -15,39 +17,39 @@ func TestBaseDatabaseURL(t *testing.T) {
 	}{
 		{
 			givenDatabaseURL: "postgres://user:password@host:5432/foobar?sslmode=disabled",
-			expectedBaseURL:  "postgres://user:password@host:5432/?sslmode=disabled",
+			expectedBaseURL:  "postgres://user:password@host:5432" + defaultDbName + "?sslmode=disabled",
 			expectedDbname:   "foobar",
 		},
 		{
 			givenDatabaseURL: "postgres://user:password@host:5432/foobar",
-			expectedBaseURL:  "postgres://user:password@host:5432/",
+			expectedBaseURL:  "postgres://user:password@host:5432" + defaultDbName,
 			expectedDbname:   "foobar",
 		},
 		{
 			givenDatabaseURL: "postgres://host:5432/foobar",
-			expectedBaseURL:  "postgres://host:5432/",
+			expectedBaseURL:  "postgres://host:5432" + defaultDbName,
 			expectedDbname:   "foobar",
 		},
 		{
 			givenDatabaseURL: "root:password@tcp(127.0.0.1:65500)/foobar?multiStatements=true",
-			expectedBaseURL:  "root:password@tcp(127.0.0.1:65500)/?multiStatements=true",
+			expectedBaseURL:  "root:password@tcp(127.0.0.1:65500)" + defaultDbName + "?multiStatements=true",
 			expectedDbname:   "foobar",
 		},
 		{
 			givenDatabaseURL: "root:password@tcp(127.0.0.1:65500)/foobar",
-			expectedBaseURL:  "root:password@tcp(127.0.0.1:65500)/",
+			expectedBaseURL:  "root:password@tcp(127.0.0.1:65500)" + defaultDbName,
 			expectedDbname:   "foobar",
 		},
 		{
 			givenDatabaseURL: "tcp(127.0.0.1:65500)/foobar",
-			expectedBaseURL:  "tcp(127.0.0.1:65500)/",
+			expectedBaseURL:  "tcp(127.0.0.1:65500)" + defaultDbName,
 			expectedDbname:   "foobar",
 		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			actualBaseURL, actualDbname, err := BaseDatabaseURL("unused", tc.givenDatabaseURL)
+			actualBaseURL, actualDbname, err := BaseDatabaseURL("unused", tc.givenDatabaseURL, defaultDbName)
 			assert.Nil(t, err)
 			assert.Equal(t, tc.expectedBaseURL, actualBaseURL)
 			assert.Equal(t, tc.expectedDbname, actualDbname)


### PR DESCRIPTION
when we are doing `-server-ready`, since `dbname` may not be created yet (see `-create-db`), we were truncating database url from `postgres://user:pass@host:port/dbname` to `postgres://user:pass@host:port/`

some cloud provider's db (e.g. Azure) does not accept such connection, so we must connect to the default databases
i.e. "postgres" for postgres, "mysql" for mysql -- how convenient!

i.e. `postgres://user:pass@host:port/postgres`
