### PR TITLE
`-server-ready` will alternate between actual db and system db connection string

### DIFF
--- a/cmd/dbmigrate/main.go
+++ b/cmd/dbmigrate/main.go
@@ -83,12 +83,11 @@ func _main() error {
 		if err != nil {
 			return errors.Wrapf(err, "database url without dbname")
 		}
-		log.Printf("connString=%q\n", connString)
 
 		if doServerReadyWait && driverName != "sqlite3" {
 			ctx, cancel := context.WithTimeout(context.Background(), serverReadyWait)
 			defer cancel()
-			if err := dbmigrate.ReadyWait(ctx, driverName, connString, log.Println); err != nil {
+			if err := dbmigrate.ReadyWait(ctx, driverName, []string{databaseURL, connString}, log.Println); err != nil {
 				return err
 			}
 		}

--- a/lib.go
+++ b/lib.go
@@ -49,10 +49,13 @@ func BaseDatabaseURL(driverName string, databaseURL string, defaultDbName string
 }
 
 // ReadyWait for server to be ready, and try to create db and connect again
-func ReadyWait(ctx context.Context, driverName string, databaseURL string, logger func(...interface{})) error {
+func ReadyWait(ctx context.Context, driverName string, databaseURLs []string, logger func(...interface{})) error {
 	logger(driverName, "checking connection")
+	count := len(databaseURLs)
+	curr := -1
 	for {
-		db, err := sql.Open(driverName, databaseURL)
+		curr = (curr + 1) % count
+		db, err := sql.Open(driverName, databaseURLs[curr])
 		if err == nil {
 			logger(driverName, "server up")
 			var num int


### PR DESCRIPTION
for the duration of retries, dbmigrate will alternate between trying to connect to the specified db
(i.e. `-url` aka `DATABASEA_URL` env) and the system db (which will always exist, but may not be accessible by the given credentials)

once either connection string works, the server is deem ready

ref https://github.com/choonkeat/dbmigrate/issues/7#issuecomment-495845110